### PR TITLE
Fix using uppercase files in Linux

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -22,7 +22,7 @@ def to_pdf_and_save(output_img, filepath):
     print('Scan saved in "scanned/" folder.\n')
 
 def single_file_procedure(f_path, colorized):
-    if f_path.split('.')[-1] not in ['jpg', 'jpeg', 'png']:
+    if f_path.split('.')[-1].lower() not in ['jpg', 'jpeg', 'png']:
             print('Unsupported format! Supported formats: .jpg, .jpeg, .png')
     else:
         scan = scan_image(f_path, colorized)


### PR DESCRIPTION
**Issue:** .JPG and .jpg files are exactly the same files, but this scanner doesn't allow to use .JPG files, though it allows .jpg files. On top of that, when you are in case-sensitive system (mainly Linux problem) and if your file is example.JPG, you can't enter example.jpg, because such file doesn't exist in your system.
This results in that scenario (in Linux): I enter "python3 src/main.py test.JPG" and get error: "Unsupported format!". I enter "python3 src/main.py test.jpg", I get "File not found!".

**Fix:** Add .lower() into checking file extension if.
